### PR TITLE
Photo queue

### DIFF
--- a/src/frame/constants.py
+++ b/src/frame/constants.py
@@ -10,12 +10,6 @@ FIT = True
 # Amount of image reflection on the background
 EDGE_ALPHA = 0.0
 BACKGROUND_COLOR = (0, 0, 0, 1)
-CODEPOINTS = '1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ., _-/'
-
-# The exif tag number for orientation
-EXIF_ORIENTATION_TAG = 274
-# Exif orientation values and corresponding degree rotation
-EXIF_ORIENTATION_DICT = {3: 180, 4: 180, 5: 270, 6: 270, 7: 90, 8: 90}
 
 # Turn off display after this many seconds without detecting motion
 SLEEP_AFTER_SECONDS = 1200

--- a/src/frame/frame.py
+++ b/src/frame/frame.py
@@ -214,7 +214,7 @@ class PhotoFrame:
         self.SLIDE.set_shader(self.SHADER)
         self.SLIDE.unif[47] = constants.EDGE_ALPHA
 
-        self.FONT = pi3d.Font(str(constants.FONT_FILE), codepoints=constants.CODEPOINTS, grid_size=7, shadow_radius=4.0,
+        self.FONT = pi3d.Font(str(constants.FONT_FILE), grid_size=7, shadow_radius=4.0,
                               shadow=(0, 0, 0, 128))
         self.TEXT = pi3d.PointText(self.FONT, self.CAMERA, max_chars=200, point_size=50)
         self.TEXTBLOCK = pi3d.TextBlock(x=-self.DISPLAY.width * 0.5 + 50, y=-self.DISPLAY.height * 0.4,

--- a/src/frame/photo_queue.py
+++ b/src/frame/photo_queue.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from typing import Tuple
+import random
+import pi3d
+
+
+class PhotoQueue:
+    def __init__(self, directory: str, shuffle: bool=True, exts: Tuple[str]=(".jpg", ".jpeg", ".png")):
+        self.directory = Path(directory)
+        if not self.directory.is_dir():
+            raise ValueError(f"{directory} is not a directory!")
+        self.shuffle = shuffle
+        self.exts = exts
+        self.photos = self._get_photos()
+        self.idx = 0
+
+    def _get_photos(self):
+        """Generate the photo list."""
+        photo_list = []
+        for ext in self.exts:
+            photo_list += list(self.directory.glob(f"*{ext}"))
+
+        if not photo_list:
+            raise FileNotFoundError(f"No photos {self.exts} found in `{self.directory}`!")
+
+        if self.shuffle:
+            random.shuffle(photo_list)
+        else:
+            photo_list.sort()
+        
+        return photo_list
+
+    def next(self):
+        """Advance the queue forward one picture.
+        
+        The photo list is regenerated after the last photo in the queue.
+        """
+        self.idx += 1
+        if self.idx >= len(self.photos):
+            self.photos = self._get_photos()
+            self.idx = 0
+        return self
+    
+    def previous(self):
+        """Advance the queue backward one picture.
+        
+        This will stop at the first photo in the queue rather than regenerating.
+        """
+        self.idx = max(0, self.idx - 1)
+
+        return self
+
+    def load(self) -> pi3d.Texture:
+        """Load the current photo in the queue as a Texture."""
+        filepath = self.photos[self.idx]
+        return pi3d.Texture(filepath, blend=True, m_repeat=True)

--- a/src/frame/photo_queue.py
+++ b/src/frame/photo_queue.py
@@ -52,5 +52,5 @@ class PhotoQueue:
 
     def load(self) -> pi3d.Texture:
         """Load the current photo in the queue as a Texture."""
-        filepath = self.photos[self.idx]
+        filepath = self.photos[self.idx].as_posix()
         return pi3d.Texture(filepath, blend=True, m_repeat=True)


### PR DESCRIPTION
Refactor the photo file management out of the `PhotoFrame` class and into a new `PhotoQueue` class. 

Note that I also removed the EXIF rotation correction because I don't think that had any benefits for my use and added complexity. It could be re-added to `PhotoQueue` pretty easily if needed.

While this change cleans things up a bit, it also makes the hackiness of the photo navigation system more apparent. Currently, loading the next picture is based only on timing, so to get the next picture we just zero the clock and to get the previous picture we have to navigate back two pictures. That's in dire need of a refactor.